### PR TITLE
Fix NPM publish workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -8,6 +8,8 @@ jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
     steps:
+      - name: Install xmllint
+        run: sudo apt-get install -y libxml2-utils
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
xmllint was missing from `ubuntu-latest`, added with apt